### PR TITLE
feat: add status codes from RFC 8132

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,6 @@ jobs:
         npm run coverage
     - name: Coveralls
       uses: coverallsapp/github-action@master
+      continue-on-error: true
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export type OptionName =
     | "Proxy-Scheme"
     | "Size1";
 
-export type CoapMethod = "GET" | "POST" | "PUT" | "DELETE";
+export type CoapMethod = "GET" | "POST" | "PUT" | "DELETE" | "FETCH" | "PATCH" | "iPATCH";
 
 export interface Packet {
     token?: Buffer;

--- a/index.js
+++ b/index.js
@@ -18,10 +18,16 @@ codes = {
   , 'POST': 2
   , 'PUT': 3
   , 'DELETE': 4
+  , 'FETCH': 5
+  , 'PATCH': 6
+  , 'iPATCH': 7
   , 'get': 1
   , 'post': 2
   , 'put': 3
   , 'delete': 4
+  , 'fetch': 5
+  , 'patch': 6
+  , 'ipatch': 7
 }
 
 module.exports.generate = function generate(packet) {


### PR DESCRIPTION
This PR adds the status codes that have been introduced in [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132#section-3.4) to the module. This enables other projects like `node-coap` to add support for the FETCH, PATCH, and iPATCH methods.