### PR TITLE
chore: Update dependencies and move CI to Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Build Status
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Perform tests and generate coverage report
+      run: |
+        npm test
+        npm run coverage
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ npm-debug.log
 .idea
 docs
 .DS_Store
+coverage
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - 0.10
-  - 0.12
-  - 4
-  - 6
-  - 7

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 CoAP-Packet
 =====
 
-[![Build
-Status](https://travis-ci.org/mcollina/coap-packet.png)](https://travis-ci.org/mcollina/coap-packet)
+![Build Status](https://github.com/mcollina/coap-packet/workflows/Build%20Status/badge.svg)
 
 __CoAP-Packet__ is a generator and parser of CoAP packets for node.js.
 

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "~7.0.11",
-    "chai": "~1.8.0",
-    "mocha": "~1.13.0",
-    "pre-commit": "0.0.3",
-    "typescript": "~2.2.2"
+    "@types/node": "^16.9.1",
+    "chai": "^4.3.4",
+    "mocha": "^9.1.1",
+    "pre-commit": "^1.2.2",
+    "typescript": "^4.4.3"
   },
   "types": "index.d.ts",
   "typings": "index.d.ts"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "tstest": "tsc -p ./ts",
-    "test": "./node_modules/.bin/mocha --bail --reporter spec --check-leaks && npm run tstest"
+    "test": "nyc mocha --exit --check-leaks && npm run tstest",
+    "coverage": "nyc report --reporter=lcov --reporter=text-summary"
   },
   "repository": {
     "type": "git",
@@ -30,6 +31,7 @@
     "@types/node": "^16.9.1",
     "chai": "^4.3.4",
     "mocha": "^9.1.1",
+    "nyc": "^15.1.0",
     "pre-commit": "^1.2.2",
     "typescript": "^4.4.3"
   },


### PR DESCRIPTION
This PR updates the project's dependencies to their latest version, adds `nyc` for code coverage determination, and moves the CI from Travis to Github Actions.