### PR TITLE
fix: allow messageId to be 0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,6 @@ jobs:
         npm run coverage
     - name: Coveralls
       uses: coverallsapp/github-action@master
+      continue-on-error: true
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export type OptionName =
     | "Proxy-Scheme"
     | "Size1";
 
-export type CoapMethod = "GET" | "POST" | "PUT" | "DELETE";
+export type CoapMethod = "GET" | "POST" | "PUT" | "DELETE" | "FETCH" | "PATCH" | "iPATCH";
 
 export interface Packet {
     token?: Buffer;

--- a/index.js
+++ b/index.js
@@ -18,10 +18,16 @@ codes = {
   , 'POST': 2
   , 'PUT': 3
   , 'DELETE': 4
+  , 'FETCH': 5
+  , 'PATCH': 6
+  , 'iPATCH': 7
   , 'get': 1
   , 'post': 2
   , 'put': 3
   , 'delete': 4
+  , 'fetch': 5
+  , 'patch': 6
+  , 'ipatch': 7
 }
 
 module.exports.generate = function generate(packet) {

--- a/index.js
+++ b/index.js
@@ -295,7 +295,7 @@ function fillGenDefaults(packet) {
   if (!packet.code)
     packet.code = '0.01'
 
-  if (!packet.messageId)
+  if (packet.messageId == null)
     packet.messageId = nextMsgId++
 
   if (!packet.options)


### PR DESCRIPTION
This PR fixes #11 and allows the `messageId` of a `packet` to be 0 by using `packet.messageId == null` as a check instead of `!packet.messageId` in the `fillGenDefaults` function.