### PR TITLE
feat: add missing CoAP option numbers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,16 +7,24 @@ export type OptionName =
     | "Uri-Port"
     | "Location-Path"
     | "Uri-Path"
+    | "OSCORE"
     | "Content-Format"
     | "Max-Age"
     | "Uri-Query"
+    | "Hop-Limit"
     | "Accept"
+    | "Q-Block1"
     | "Location-Query"
     | "Block2"
     | "Block1"
+    | "Size2"
+    | "Q-Block2"
     | "Proxy-Uri"
     | "Proxy-Scheme"
-    | "Size1";
+    | "Size1"
+    | "No-Response"
+    | "OCF-Accept-Content-Format-Version"
+    | "OCF-Content-Format-Version";
 
 export type CoapMethod = "GET" | "POST" | "PUT" | "DELETE" | "FETCH" | "PATCH" | "iPATCH";
 

--- a/index.js
+++ b/index.js
@@ -169,17 +169,25 @@ const numMap = {
   6: 'Observe',
   7: 'Uri-Port',
   8: 'Location-Path',
+  9: 'OSCORE',
   11: 'Uri-Path',
   12: 'Content-Format',
   14: 'Max-Age',
   15: 'Uri-Query',
+  16: 'Hop-Limit',
   17: 'Accept',
+  19: 'Q-Block1',
   20: 'Location-Query',
   23: 'Block2',
   27: 'Block1',
+  28: 'Size2',
+  31: 'Q-Block2',
   35: 'Proxy-Uri',
   39: 'Proxy-Scheme',
-  60: 'Size1'
+  60: 'Size1',
+  258: 'No-Response',
+  2049: 'OCF-Accept-Content-Format-Version',
+  2053: 'OCF-Content-Format-Version'
 }
 
 const optionNumberToString = (function genOptionParser () {

--- a/test.js
+++ b/test.js
@@ -866,7 +866,8 @@ describe('packet.generate', function () {
       Block1: 27,
       'Proxy-Uri': 35,
       'Proxy-Scheme': 39,
-      Size1: 60
+      Size1: 60,
+      'No-Response': 258
     }
 
     Object.keys(longOptions).forEach(function (option) {
@@ -921,8 +922,15 @@ describe('packet.generate', function () {
       })
     })
 
-    ;['560', '720'].forEach(function (option) {
-      const optionNum = '' + option
+    const evenLongerOptions = {
+      560: 560,
+      720: 720,
+      'OCF-Accept-Content-Format-Version': 2049,
+      'OCF-Content-Format-Version': 2053
+    }
+
+    Object.keys(evenLongerOptions).forEach(function (option) {
+      const optionNum = evenLongerOptions[option]
 
       it('should generate ' + option + ' option with unextended length', function () {
         packet = {

--- a/test.js
+++ b/test.js
@@ -238,7 +238,7 @@ describe('packet.parse', function () {
       // this is not specified by the protocol,
       // but it's needed to check if it can parse
       // numbers
-      9: 9
+      10: 10
     }
 
     Object.keys(options).forEach(function (option) {
@@ -305,7 +305,7 @@ describe('packet.parse', function () {
       // this is not specified by the protocol,
       // but it's needed to check if it can parse
       // numbers
-      16: '16'
+      13: '13'
     }
 
     Object.keys(options).forEach(function (num) {
@@ -560,7 +560,7 @@ describe('packet.parse', function () {
       // this is not specified by the protocol,
       // but it's needed to check if it can parse
       // numbers
-      9: 9
+      10: 10
     }
 
     Object.keys(options).forEach(function (option) {
@@ -857,9 +857,9 @@ describe('packet.generate', function () {
     })
 
     const longOptions = {
+      13: 13, // unknown, just to be sure it parses
       'Max-Age': 14,
       'Uri-Query': 15,
-      16: 16, // unknown, just to be sure it parses
       Accept: 17,
       'Location-Query': 20,
       Block2: 23,


### PR DESCRIPTION
This PR adds a couple of option numbers from the [IANA registry](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#option-numbers) which are currently missing in `coap-packet`.