### PR TITLE
feat: implement RFC 8974 (extended token length)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ What is CoAP?
 intended to be used in very simple electronics devices that allows them
 to communicate interactively over the Internet. -  Wikipedia
 
-This library follows [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252) for generating and parsing of CoAP packets.
+This library follows [RFC 7252](https://datatracker.ietf.org/doc/html/rfc7252) and [RFC 8974](https://datatracker.ietf.org/doc/html/rfc8974) for generating and parsing of CoAP packets.
 It also supports the method and option codes specified by other specifications, such as [RFC 7641](https://datatracker.ietf.org/doc/html/rfc7641), [RFC 7959](https://datatracker.ietf.org/doc/html/rfc7959), and [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132).
 
 It does not provide any CoAP semantics, it just parses the protocol.

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,5 +63,5 @@ export interface Option {
     value: Buffer;
 }
 
-export function generate(packet: Packet): Buffer;
+export function generate(packet: Packet, maxLength?: number): Buffer;
 export function parse(buffer: Buffer): ParsedPacket;

--- a/index.js
+++ b/index.js
@@ -34,6 +34,16 @@ module.exports.generate = function generate (packet) {
   packet = fillGenDefaults(packet)
   const options = prepareOptions(packet)
   const length = calculateLength(packet, options)
+  const tokenLength = packet.token.length
+  let tokenMask
+
+  if (tokenLength < 13) {
+    tokenMask = tokenLength
+  } else if (tokenLength < 270) {
+    tokenMask = 13
+  } else if (tokenLength < 65805) {
+    tokenMask = 14
+  }
 
   if (length > 1280) {
     throw new Error('Max packet size is 1280: current is ' + length)
@@ -45,7 +55,7 @@ module.exports.generate = function generate (packet) {
   let byte = 0
   byte |= 1 << 6 // first two bits are version
   byte |= confirmableAckResetMask(packet)
-  byte |= packet.token.length
+  byte |= tokenMask
   buffer.writeUInt8(byte, pos++)
 
   // code can be humized or not
@@ -59,9 +69,17 @@ module.exports.generate = function generate (packet) {
   buffer.writeUInt16BE(packet.messageId, pos)
   pos += 2
 
+  if (tokenLength > 268) {
+    buffer.writeUInt16BE(tokenLength - 269, pos)
+    pos += 2
+  } else if (tokenLength > 12) {
+    buffer.writeUInt8(tokenLength - 13, pos)
+    pos++
+  }
+
   // the token might be an empty buffer
   packet.token.copy(buffer, pos)
-  pos += packet.token.length
+  pos += tokenLength
 
   // write the options
   for (let i = 0; i < options.length; i++) {
@@ -148,9 +166,15 @@ function parseCode (buffer) {
 }
 
 function parseToken (buffer) {
-  const length = buffer.readUInt8(0) & 15
+  let length = buffer.readUInt8(0) & 15
 
-  if (length > 8) {
+  if (length === 13) {
+    length = buffer.readUInt8(index) + 13
+    index += 1
+  } else if (length === 14) {
+    length = buffer.readUInt16BE(index) + 269
+    index += 2
+  } else if (length === 15) {
     throw new Error('Token length not allowed')
   }
 
@@ -286,7 +310,7 @@ function fillGenDefaults (packet) {
     packet.token = empty
   }
 
-  if (packet.token.length > 8) {
+  if (packet.token.length > 65804) {
     throw new Error('Token too long')
   }
 
@@ -339,6 +363,14 @@ function confirmableAckResetMask (packet) {
 
 function calculateLength (packet, options) {
   let length = 4 + packet.payload.length + packet.token.length
+
+  if (packet.token.length > 12) {
+    length += 1
+  }
+
+  if (packet.token.length > 268) {
+    length += 1
+  }
 
   if (packet.code !== '0.00' && packet.payload.toString() !== '') {
     length += 1

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const codes = {
   ipatch: 7
 }
 
-module.exports.generate = function generate (packet) {
+module.exports.generate = function generate (packet, maxLength = 1280) {
   let pos = 0
 
   packet = fillGenDefaults(packet)
@@ -45,8 +45,8 @@ module.exports.generate = function generate (packet) {
     tokenMask = 14
   }
 
-  if (length > 1280) {
-    throw new Error('Max packet size is 1280: current is ' + length)
+  if (length > maxLength) {
+    throw new Error(`Max packet size is ${maxLength}: current is ${length}`)
   }
 
   const buffer = Buffer.alloc(length)


### PR DESCRIPTION
This PR adds the possibility to parse and create packets with extended tokens as specified by [RFC 8974](https://datatracker.ietf.org/doc/html/rfc8974). 